### PR TITLE
Run smbserver and dnsmask in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,8 @@ particular exploitation strategy or prepare both scenarios:
 make
 ```
 
-This requires a working Docker setup. For the actual exploitation you will
-also need:
-
- - dnsmasq
- - impacket's smbserver.py
- - GDB with Python support (for the WinPE-based attack strategy)
+This requires a working Docker setup. For the WinPE-based attack strategy
+you also need GDB with Python support.
 
 ### Linux Initramfs Generation
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ wpeutil initializenetwork
 ```
 
 > [!note]
-> You should see DHCP request served by `dnsmasq`.
+> You should see DHCP request served by `dnsmasq`. You can check the ip with `ipconfig` and also try to ping the attack machine `ping 10.13.37.100`.
 
 Mount the exposed SMB share:
 ```
@@ -200,7 +200,7 @@ boot configuration then fall back to the served Linux environment.
 
 Login with the `root` user, no password is needed. Follow the instructions
 printed in the logon message.  Replace `XYZ` with device file representing
-your encrypted BitLocker volume:
+your encrypted BitLocker volume (use `lsblk -f`):
 
 ```
 exploit && ./mount.sh /dev/XYZ && ls mnt

--- a/pxe/start-pxe-linux.sh
+++ b/pxe/start-pxe-linux.sh
@@ -7,10 +7,18 @@ interface=$1
 
 sudo ip a add 10.13.37.100/24 dev $interface
 
-sudo dnsmasq --no-daemon \
+# We need host network because dnsmasq checks if it binds to an address in 10.13.37.0/24
+sudo docker run --cap-add=NET_ADMIN \
+    --volume="$scriptpath/tftp":/data \
+    --volume="$scriptpath/smb/BCD":/data/Boot/BCD \
+    --network host \
+    4km3/dnsmasq --no-daemon \
+    --log-facility=- \
 	--interface=$interface \
 	--dhcp-range=10.13.37.100,10.13.37.200,255.255.255.0,1h \
 	--dhcp-boot=bootmgfw.efi \
 	--enable-tftp \
-	--tftp-root="$scriptpath/tftp" \
+	--tftp-root=/data \
 	--log-dhcp
+
+

--- a/pxe/start-smb.sh
+++ b/pxe/start-smb.sh
@@ -2,4 +2,8 @@
 
 scriptpath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-sudo $(which smbserver.py) -smb2support smb "$scriptpath/smb"
+sudo docker run --platform linux/amd64 --rm \
+    -p 445:445/tcp \
+    -v "$scriptpath/smb":/data \
+    4poki4/impacket \
+    smbserver.py -smb2support smb /data


### PR DESCRIPTION
Hey,

thanks for your work and the docs! I tried it and it worked like charm. In my case network boot was disabled, but I could just enable it in the firmware.

I added some debugging hints in the docs and start dnsmasc and smbserver in docker. I just used "random" images for that. The smbserver one needs to be kinda up-to-date (had problems with 10.x. I thinks this one is 11.x and works. current version is 12.x).

